### PR TITLE
Fix linux build scripts

### DIFF
--- a/releases/build_rom.ini
+++ b/releases/build_rom.ini
@@ -1,5 +1,4 @@
-zip0=gberet.zip
-zip1=rushatck.zip
+zips=( gberet.zip rushatck.zip )
 ifiles=( 577h03.10c 577h02.8c 577h01.7c 577h01.7c 577l06.5e 577h05.4e 577l08.4f 577l04.3e 577h07.3f 577h10.5f 577h11.6f 577h09.2f )
 ofile=a.rshnatk.rom
 ofileMd5sumValid=77c3e9fb3763204f8e118a7442991c6e

--- a/releases/build_rom.sh
+++ b/releases/build_rom.sh
@@ -24,34 +24,31 @@ check_permissions () {
 }
 
 read_ini () {
-  if [ ! -f ${BASEDIR}/build_rom_RushAtck.ini ]; then
-    exit_with_error "Missing build_rom_RushAtck.ini"
+  if [ ! -f ${BASEDIR}/build_rom.ini ]; then
+    exit_with_error "Missing build_rom.ini"
   else
-    source ${BASEDIR}/build_rom_RushAtck.ini
+    source ${BASEDIR}/build_rom.ini
   fi
 }
 
-uncompress_zip() {
+uncompress_zips() {
   tmpdir=tmp.`date +%Y%m%d%H%M%S%s`
-  if [ -f ${BASEDIR}/${zip0} ]; then
-    unzip -qq -d ${BASEDIR}/${tmpdir}/ ${BASEDIR}/${zip0}
-    if [ $? != 0 ] ; then
-      rm -rf ${BASEDIR}/$tmpdir
-      exit_with_error "Something went wrong\nwhen extracting\n${zip0}"
-    fi
-  else
-    exit_with_error "Cannot find ${zip0}"
-  fi
-  if [ -f ${BASEDIR}/${zip1} ]; then
-    unzip -qq -d ${BASEDIR}/${tmpdir}/ ${BASEDIR}/${zip1}
-    if [ $? != 0 ] ; then
-      rm -rf ${BASEDIR}/$tmpdir
-      exit_with_error "Something went wrong\nwhen extracting\n${zip1}"
-    fi
-  else
-    rm -rf ${BASEDIR}/$tmpdir
-    exit_with_error "Cannot find ${zip1}"
-  fi
+  local z=''
+
+  for z in "${zips[@]}"; do
+      if [[ ! -f ${BASEDIR}/${z} ]]; then
+        exit_with_error "Cannot find ${z}"
+      fi
+  done
+
+  for z in "${zips[@]}"; do
+      echo "Unzipping $z"
+      unzip -qq -o -d ${BASEDIR}/${tmpdir}/ ${BASEDIR}/${z}
+      if [ $? != 0 ] ; then
+        rm -rf ${BASEDIR}/$tmpdir
+        exit_with_error "Something went wrong\nwhen extracting\n${z}"
+      fi
+  done
 }
 
 generate_rom() {
@@ -101,7 +98,7 @@ check_permissions
 read_ini
 
 ## extract package
-uncompress_zip
+uncompress_zips
 
 ## build rom
 generate_rom

--- a/releases/build_rom_alt.sh
+++ b/releases/build_rom_alt.sh
@@ -24,10 +24,10 @@ check_permissions () {
 }
 
 read_ini () {
-  if [ ! -f ${BASEDIR}/build_rom.ini ]; then
-    exit_with_error "Missing build_rom.ini"
+  if [ ! -f ${BASEDIR}/build_rom_alt.ini ]; then
+    exit_with_error "Missing build_rom_alt.ini"
   else
-    source ${BASEDIR}/build_rom.ini
+    source ${BASEDIR}/build_rom_alt.ini
   fi
 }
 


### PR DESCRIPTION
Fix for linux build scripts and change to "zips" format for multiple input files, as used in other cores, for consistency and also compatibility with the automatic mame conversion script.